### PR TITLE
Removed unexisting dependency

### DIFF
--- a/src/example-app/js-sdk/globalcollect/session.js
+++ b/src/example-app/js-sdk/globalcollect/session.js
@@ -1,4 +1,4 @@
-define("GCsdk.Session", ["GCsdk.core", "GCsdk.C2SCommunicator", "GCsdk.C2SCommunicatorConfiguration", "GCsdk.IinDetailsResponse", "GCsdk.promise", "GCsdk.C2SPaymentProductContext", "GCsdk.ValidationRule", "GCsdk.PaymentProducts", "GCsdk.PaymentProduct", "GCsdk.PaymentRequest", "GCsdk.Encryptor"], function(GCsdk, C2SCommunicator, C2SCommunicatorConfiguration, IinDetailsResponse, Promise, C2SPaymentProductContext, ValidationRule, PaymentProducts, PaymentProduct, PaymentRequest, Encryptor) {
+define("GCsdk.Session", ["GCsdk.core", "GCsdk.C2SCommunicator", "GCsdk.C2SCommunicatorConfiguration", "GCsdk.IinDetailsResponse", "GCsdk.promise", "GCsdk.C2SPaymentProductContext", "GCsdk.PaymentProducts", "GCsdk.PaymentProduct", "GCsdk.PaymentRequest", "GCsdk.Encryptor"], function(GCsdk, C2SCommunicator, C2SCommunicatorConfiguration, IinDetailsResponse, Promise, C2SPaymentProductContext, PaymentProducts, PaymentProduct, PaymentRequest, Encryptor) {
 
 	var session = function (sessionDetails, paymentProduct) {
 


### PR DESCRIPTION
I had problems integrating this library with Magento 2 and RequireJS. Looks like the required dependency `GCsdk.ValidationRule` required in `session.js` does not exist.
