### PR TITLE
fix #3 - use of AndroidPay variable in the local scope when it's stor…

### DIFF
--- a/src/AndroidPay.js
+++ b/src/AndroidPay.js
@@ -150,6 +150,6 @@ define("connectsdk.AndroidPay", ["connectsdk.core", "connectsdk.promise", "conne
             }
         }
     };
-    connectsdk.AndroidPay = AndroidPay;
-    return AndroidPay;
+    connectsdk.AndroidPay = this.AndroidPay;
+    return this.AndroidPay;
 });


### PR DESCRIPTION
The AndroidPay variable, in the local scope is used but not defined.
It's in fact stored in the this reference.