### PR TITLE
added responseJSON to failure case in iinDetailsResponse

### DIFF
--- a/src/C2SCommunicator.js
+++ b/src/C2SCommunicator.js
@@ -385,6 +385,7 @@ define("connectsdk.C2SCommunicator", ["connectsdk.core", "connectsdk.promise", "
 								}
 							} else {
 								iinDetailsResponse.status = "UNKNOWN";
+								iinDetailsResponse.json = res.responseJSON;
 								promise.reject(iinDetailsResponse);
 							}
 						});


### PR DESCRIPTION
there is no way to find out if clientSessionId has expired because C2SCommunicator.getPaymentProductIdByCreditCardNumber doesn't populate any error details in the "reject" call resulting in the response similar to this:

```
{
  status: 'UNKNOWN',
  countryCode: '',
  paymentProductId: '',
  isAllowedInContext: '',
  coBrands: []
}
```

This fix populates server side response and gives a consumer an ability to access returned errors, resulting in a response similar to this:

```
{
	"status": "UNKNOWN",
	"countryCode": "",
	"paymentProductId": "",
	"isAllowedInContext": "",
	"coBrands": [],
	"json": {
		"errorId": "5f0e4c9cba740e7302c53b70867539a4",
		"errors": [
			{
				"code": "9008",
				"id": "ACCESS_TO_CONSUMER_ID_NOT_ALLOWED",
				"category": "CONNECT_PLATFORM_ERROR",
				"message": "ACCESS_TO_CONSUMER_ID_NOT_ALLOWED",
				"httpStatusCode": 403
			}
		]
	}
}
```